### PR TITLE
Make identifying tests based on filename optional. Default true.

### DIFF
--- a/README.ct-findtargets.rst
+++ b/README.ct-findtargets.rst
@@ -25,6 +25,7 @@ ct-findtargets [-h] [-c CONFIG_FILE] [--variant VARIANT] [-v] [-q]
                     [--objdir OBJDIR] [--exemarkers EXEMARKERS]
                     [--testmarkers TESTMARKERS] [--auto | --no-auto]
                     [--style {indent,null,args,flat}]
+                    [--filenametestmatch | --no-filenametestmatch]
 
 
 DESCRIPTION
@@ -37,7 +38,7 @@ compile to either an executable or a unit test.  The default settings are
 * testmarkers = unit_test.hpp
 
 A filename that starts with "test" and also satisfies the exemarkers will 
-be reported as a test.
+be reported as a test, unless --no-filenametestmatch is set.
 
 EXAMPLES
 ========

--- a/ct/findtargets.py
+++ b/ct/findtargets.py
@@ -36,6 +36,12 @@ def add_arguments(cap):
         default='indent',
         help="Output formatting style")
 
+    ct.utils.add_flag_argument(
+        parser=cap,
+        name="filenametestmatch",
+        default=True,
+        help="Identify tests based on filename in addition to testmarkers")
+
 
 class NullStyle(object):
 
@@ -125,7 +131,8 @@ class FindTargets(object):
                                for marker in self._args.exemarkers):
                             # A file starting with test....cpp will be interpreted
                             # As a test even though it satisfied the exemarker
-                            if filename.startswith('test'):
+                            if filename.startswith('test') and \
+                                    self._args.filenametestmatch:
                                 testtargets.append(pathname)
                                 if self._args.verbose >= 3:
                                     print("Found a test: " + pathname)


### PR DESCRIPTION
Add the option to disable the default behaviour of identifying tests based on filename.

We have source files named "test.*" that aren't unit tests.