### PR TITLE
Prevent serialise-tests consuming an argument.

### DIFF
--- a/ct/cake.py
+++ b/ct/cake.py
@@ -150,7 +150,7 @@ class Cake(object):
             "--output",
             help="When there is only a single build product, rename it to this name.")
 
-        ct.utils.add_boolean_argument(
+        ct.utils.add_flag_argument(
             parser=cap,
             name="serialise-tests",
             dest="serialisetests",


### PR DESCRIPTION
We found that --serialise-tests was consuming the subsequent argument and throwing an "invalid tobool":

`ct-cake --auto --serialise-tests ./test/testCode.cpp`
`ct-cake: error: argument --serialise-tests: invalid tobool value: './test/testCode.cpp'`

We've worked around it with:

`ct-cake --auto --serialise-tests true ./test/testCode.cpp`

So this change may have compatibility impacts on people who've worked around this bug in the same way.
