### PR TITLE
Add selective building

### DIFF
--- a/README.ct-cake.rst
+++ b/README.ct-cake.rst
@@ -145,6 +145,17 @@ strictly needed to build your particular binary, so you only pay for what
 you use. This difference alone should see a large improvement on most
 projects, especially for incremental rebuilds.
 
+Selective build and test
+===========
+
+You can instruct ct-cake to only build binarires dependant on a list of
+source files using the ``--build-only-changed`` flag. This is helpful for
+limiting building and testing in a Continuous Integration pipeline to only
+source that has changed from master.
+
+``changed_source=git diff --name-only master | sed "s,^,$(git rev-parse --show-toplevel)/,"
+ct-cake --auto --build-only-changed \"$changed_source\"``
+
 Configuration
 =============
 

--- a/README.ct-cake.rst
+++ b/README.ct-cake.rst
@@ -148,7 +148,7 @@ projects, especially for incremental rebuilds.
 Selective build and test
 ===========
 
-You can instruct ct-cake to only build binarires dependant on a list of
+You can instruct ct-cake to only build binaries dependant on a list of
 source files using the ``--build-only-changed`` flag. This is helpful for
 limiting building and testing in a Continuous Integration pipeline to only
 source that has changed from master.

--- a/ct/makefile.py
+++ b/ct/makefile.py
@@ -536,14 +536,15 @@ class MakefileCreator:
             changed_files = set(self.args.build_exclusively.split())
             neccessary_rules = set()
             prev_neccessary_rules_count = -1
-            while len(neccessary_rules) != prev_neccessary_rules_count
+            while len(neccessary_rules) != prev_neccessary_rules_count:
                 # This will break out of the loop if neccessary_rules stops growing.
                 prev_neccessary_rules_count = len(neccessary_rules)
                 for rule in self.rules:
                     if rule.phony:
                         neccessary_rules.add(rule)
                         continue
-                    rule.all_prerequisites_set = set(rule.prerequisites.split()) + set(rule.order_only_prerequisites.split())
+                    rule.all_prerequisites_set = set(rule.prerequisites.split())
+                    # rule.all_prerequisites_set = set(rule.prerequisites.split()) + set(rule.order_only_prerequisites.split())
                     if rule.all_prerequisites_set.intersection(changed_files):
                         neccessary_rules.add(rule)
                         continue

--- a/ct/makefile.py
+++ b/ct/makefile.py
@@ -222,7 +222,7 @@ class MakefileCreator:
             help="Output filename for the Makefile")
         cap.add(
             "--build-only-changed",
-            help="Only build the binaries depending on the source or header absolute filenames in this list.")
+            help="Only build the binaries depending on the source or header absolute filenames in this space-delimited list.")
 
     def _uptodate(self):
         """ Is the Makefile up to date?
@@ -587,7 +587,6 @@ class MakefileCreator:
         # (or library as appropriate)
         rules_for_source = ct.utils.OrderedSet()
 
-        # put the filtering in here somewhere
         # Output all the link rules
         if self.args.verbose >= 3:
             print("Creating link rule for ", sources)

--- a/ct/makefile.py
+++ b/ct/makefile.py
@@ -534,30 +534,26 @@ class MakefileCreator:
 
         if self.args.build_exclusively:
             changed_files = set(self.args.build_exclusively.split(' '))
-            neccessary_rules = set()
             targets = set()
             done = False
             while not done:
                 done = True
                 for rule in self.rules:
-                    # if rule.phony:
-                        # continue
                     if rule.target in changed_files:
                         continue
-                    if set(rule.prerequisites.split(' ')).intersection(changed_files):
+                    relevant_changed_files = set(rule.prerequisites.split(' ')).intersection(changed_files)
+                    if relevant_changed_files:
                         changed_files.add(rule.target)
                         targets.add(rule.target)
                         done = False
-                        print("Keeping {} because it depends on changed: {}".format(rule.target, list(set(rule.prerequisites.split(' ')).intersection(changed_files))))
+                        # if self.args.verbose >= 3:
+                            print("Building {} because it depends on changed: {}".format(rule.target, list(relevant_changed_files)))
             new_rules = ct.utils.OrderedSet()
             for rule in self.rules:
                 if not rule.phony:
                     new_rules.add(rule)
-                    continue
-                if rule.target in ["build", "runtests"]:
-                    rule.prerequisites = ' '.join(set(rule.prerequisites.split()).intersection(targets))
-                    new_rules.add(rule)
                 else:
+                    rule.prerequisites = ' '.join(set(rule.prerequisites.split()).intersection(targets))
                     new_rules.add(rule)
             self.rules = new_rules
 

--- a/ct/makefile.py
+++ b/ct/makefile.py
@@ -507,7 +507,7 @@ class MakefileCreator:
             while not done:
                 done = True
                 for rule in self.rules:
-                    if rule.target in changed_files:
+                    if rule.target in targets:
                         continue
                     relevant_changed_files = set(rule.prerequisites.split(' ')).intersection(changed_files)
                     if not relevant_changed_files:

--- a/ct/makefile.py
+++ b/ct/makefile.py
@@ -515,7 +515,8 @@ class MakefileCreator:
                     changed_files.add(rule.target)
                     targets.add(rule.target)
                     done = False
-                    print("Building {} because it depends on changed: {}".format(rule.target, list(relevant_changed_files)))
+                    if self.args.verbose >=3:
+                        print("Building {} because it depends on changed: {}".format(rule.target, list(relevant_changed_files)))
             new_rules = ct.utils.OrderedSet()
             for rule in self.rules:
                 if not rule.phony:

--- a/ct/makefile.py
+++ b/ct/makefile.py
@@ -220,6 +220,9 @@ class MakefileCreator:
             "--makefilename",
             default="Makefile",
             help="Output filename for the Makefile")
+        cap.add(
+            "--build-exclusively",
+            help="Only build the binaries depending on the source or header absolute filenames in this list.")
 
     def _uptodate(self):
         """ Is the Makefile up to date?
@@ -446,6 +449,38 @@ class MakefileCreator:
             realpath_tests = sorted(
                 ct.wrappedos.realpath(source) for source in self.args.tests)
             realpath_sources += realpath_tests
+        # if self.args.build_exclusively:
+        #     print("Sources: {}".format(realpath_sources))
+        #     changed_files = set(self.args.build_exclusively.split())
+        #     print("changed_files: {}".format(changed_files))
+        #     realpath_sources = list(set(realpath_sources).intersection(changed_files))
+        #     print("Sources: {}".format(realpath_sources))
+            
+            # filtered_rules = []
+            # minimal_set_rules = []
+            # changed_files = set(self.args.build_exclusively.split())
+            # for rule in self.rules:
+            #     if set(rule.prerequisites.split()).intersection(changed_files) or rule.phony:
+            #         print("{} is buildworthy".format(rule.target))
+            #         minimal_set_rules.append(rule)
+            # for rule in self.rules:
+            #     for minimal_rule in minimal_set_rules:
+            #         filtered_rules.append(minimal_rule)
+            #         if minimal_rule.target in rule.prerequisites:
+            #             if rule not in filtered_rules:
+            #                 filtered_rules.append(rule)
+                        
+                
+            #     # woo = completesources.intersection(changed_files)
+            #     # if not woo:
+            #     #     self._skip_files.add(source)
+            #     #     continue
+            #     # print("{} is buildworthy because of the following changes:".format(source))
+            #     # for a in woo:
+            #     #     print("Intersection: " + a)
+            # self.rules = filtered_rules
+            # # for rule in self.rules:
+            #     print(rule)
 
         if self.args.filename or self.args.tests:
             allexes = {
@@ -559,6 +594,7 @@ class MakefileCreator:
         # (or library as appropriate)
         rules_for_source = ct.utils.OrderedSet()
 
+        # put the filtering in here somewhere
         # Output all the link rules
         if self.args.verbose >= 3:
             print("Creating link rule for ", sources)
@@ -569,6 +605,16 @@ class MakefileCreator:
             args=self.args,
             namer=self.namer,
             hunter=self.hunter)
+        print("Zimbu")
+        print(linkrulecreatorobject)
+        if self.args.build_exclusively:
+            changed_files = set(self.args.build_exclusively.split())
+            print("Sources: {}".format(sources))
+            This won't work. We need to pass something to the hunter that can nix a source file if 
+            it doesn't find anything that matches the list of changed files.
+        #     print("changed_files: {}".format(changed_files))
+        #     realpath_sources = list(set(realpath_sources).intersection(changed_files))
+        #     print("Sources: {}".format(realpath_sources))
         rules_for_source |= linkrulecreatorobject(
             libraryname=libraryname,
             sources=sources)

--- a/ct/makefile.py
+++ b/ct/makefile.py
@@ -221,7 +221,7 @@ class MakefileCreator:
             default="Makefile",
             help="Output filename for the Makefile")
         cap.add(
-            "--build-exclusively",
+            "--build-only-changed",
             help="Only build the binaries depending on the source or header absolute filenames in this list.")
 
     def _uptodate(self):
@@ -449,38 +449,6 @@ class MakefileCreator:
             realpath_tests = sorted(
                 ct.wrappedos.realpath(source) for source in self.args.tests)
             realpath_sources += realpath_tests
-        # if self.args.build_exclusively:
-        #     print("Sources: {}".format(realpath_sources))
-        #     changed_files = set(self.args.build_exclusively.split())
-        #     print("changed_files: {}".format(changed_files))
-        #     realpath_sources = list(set(realpath_sources).intersection(changed_files))
-        #     print("Sources: {}".format(realpath_sources))
-            
-            # filtered_rules = []
-            # minimal_set_rules = []
-            # changed_files = set(self.args.build_exclusively.split())
-            # for rule in self.rules:
-            #     if set(rule.prerequisites.split()).intersection(changed_files) or rule.phony:
-            #         print("{} is buildworthy".format(rule.target))
-            #         minimal_set_rules.append(rule)
-            # for rule in self.rules:
-            #     for minimal_rule in minimal_set_rules:
-            #         filtered_rules.append(minimal_rule)
-            #         if minimal_rule.target in rule.prerequisites:
-            #             if rule not in filtered_rules:
-            #                 filtered_rules.append(rule)
-                        
-                
-            #     # woo = completesources.intersection(changed_files)
-            #     # if not woo:
-            #     #     self._skip_files.add(source)
-            #     #     continue
-            #     # print("{} is buildworthy because of the following changes:".format(source))
-            #     # for a in woo:
-            #     #     print("Intersection: " + a)
-            # self.rules = filtered_rules
-            # # for rule in self.rules:
-            #     print(rule)
 
         if self.args.filename or self.args.tests:
             allexes = {
@@ -532,8 +500,8 @@ class MakefileCreator:
 
         self.rules |= self._create_clean_rules(buildoutputs)
 
-        if self.args.build_exclusively:
-            changed_files = set(self.args.build_exclusively.split(' '))
+        if self.args.build_only_changed:
+            changed_files = set(self.args.build_only_changed.split(' '))
             targets = set()
             done = False
             while not done:

--- a/ct/makefile.py
+++ b/ct/makefile.py
@@ -532,6 +532,28 @@ class MakefileCreator:
 
         self.rules |= self._create_clean_rules(buildoutputs)
 
+        if self.args.build_exclusively:
+            changed_files = set(self.args.build_exclusively.split())
+            neccessary_rules = set()
+            prev_neccessary_rules_count = -1
+            while len(neccessary_rules) != prev_neccessary_rules_count
+                # This will break out of the loop if neccessary_rules stops growing.
+                prev_neccessary_rules_count = len(neccessary_rules)
+                for rule in self.rules:
+                    if rule.phony:
+                        neccessary_rules.add(rule)
+                        continue
+                    rule.all_prerequisites_set = set(rule.prerequisites.split()) + set(rule.order_only_prerequisites.split())
+                    if rule.all_prerequisites_set.intersection(changed_files):
+                        neccessary_rules.add(rule)
+                        continue
+                    for neccessary_rule in neccessary_rules:
+                        if neccessary_rule.target in rule.all_prerequisites_set:
+                            neccessary_rules.add(rule)
+                        if rule.target in neccessary_rules.all_prerequisites_set:
+                            neccessary_rules.add(rule)
+                self.rules = list(neccessary_rules)
+
         self.write(self.args.makefilename)
         return self.args.makefilename
 
@@ -605,16 +627,6 @@ class MakefileCreator:
             args=self.args,
             namer=self.namer,
             hunter=self.hunter)
-        print("Zimbu")
-        print(linkrulecreatorobject)
-        if self.args.build_exclusively:
-            changed_files = set(self.args.build_exclusively.split())
-            print("Sources: {}".format(sources))
-            This won't work. We need to pass something to the hunter that can nix a source file if 
-            it doesn't find anything that matches the list of changed files.
-        #     print("changed_files: {}".format(changed_files))
-        #     realpath_sources = list(set(realpath_sources).intersection(changed_files))
-        #     print("Sources: {}".format(realpath_sources))
         rules_for_source |= linkrulecreatorobject(
             libraryname=libraryname,
             sources=sources)

--- a/ct/makefile.py
+++ b/ct/makefile.py
@@ -510,12 +510,12 @@ class MakefileCreator:
                     if rule.target in changed_files:
                         continue
                     relevant_changed_files = set(rule.prerequisites.split(' ')).intersection(changed_files)
-                    if relevant_changed_files:
-                        changed_files.add(rule.target)
-                        targets.add(rule.target)
-                        done = False
-                        # if self.args.verbose >= 3:
-                            print("Building {} because it depends on changed: {}".format(rule.target, list(relevant_changed_files)))
+                    if not relevant_changed_files:
+                        continue
+                    changed_files.add(rule.target)
+                    targets.add(rule.target)
+                    done = False
+                    print("Building {} because it depends on changed: {}".format(rule.target, list(relevant_changed_files)))
             new_rules = ct.utils.OrderedSet()
             for rule in self.rules:
                 if not rule.phony:

--- a/ct/utils.py
+++ b/ct/utils.py
@@ -184,6 +184,12 @@ class OrderedSet(collections.MutableSet):
                 output.add(key)
         return output
 
+    def intersection(self, iterable):
+        output = OrderedSet()
+        for key in self.map:
+            if key in iterable:
+                output.add(key)
+        return output
 
     def __iter__(self):
         end = self.end


### PR DESCRIPTION
Adds a --build-only-changed flag that accepts a space-delimited list of source files. The makefile is filtered to include only targets depending on those source files.

I imagine this could be accomplished more efficiently by changing the behaviour of the hunter, but I repeatedly ran aground on curly dependencies, so I went with the soft option.